### PR TITLE
Prevent text overflowing image sides

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,6 @@
 
 .fill-screen {
 	position: fixed;
-	left: 0;
-	right: 0;
-	top: 0;
-	bottom: 0;
 }
 
 .fit-image {


### PR DESCRIPTION
image now doesn't downscreen to screen size. But text doesn't overflow the image width.